### PR TITLE
refactor(api): remove redundant mongoose.model("Game") calls

### DIFF
--- a/pages/api/partidas/[id].js
+++ b/pages/api/partidas/[id].js
@@ -2,7 +2,6 @@
 import dbConnect from "../../../lib/dbConnect";
 import Partida from "../../../models/Partida";
 import Game from "../../../models/Game";
-mongoose.model("Game");
 
 export default async function handler(req, res) {
   await dbConnect();

--- a/pages/api/partidas/index.js
+++ b/pages/api/partidas/index.js
@@ -5,7 +5,6 @@ import mongoose from "mongoose";
 import webpush from "web-push";
 import Subscription from "../../../models/Subscription";
 import Game from "../../../models/Game";
-mongoose.model("Game");
 
 // Configurar VAPID (asegúrate de tener las variables definidas en tu .env)
 webpush.setVapidDetails(


### PR DESCRIPTION
The mongoose.model("Game") calls were redundant since the Game model is already imported and used directly. This cleanup improves code readability and maintainability by removing unnecessary lines.