### PR TITLE
refactor(api): replace getServerSession with getSession for consistency

### DIFF
--- a/pages/api/upload/index.js
+++ b/pages/api/upload/index.js
@@ -1,5 +1,5 @@
 import { v2 as cloudinary } from 'cloudinary';
-import { getServerSession } from 'next-auth/react';
+import { getSession } from 'next-auth/react';
 import formidable from 'formidable';
 
 // Configurar para que Next.js no analice el cuerpo de la solicitud como JSON
@@ -17,7 +17,7 @@ cloudinary.config({
 });
 
 export default async function handler(req, res) {
-  const session = await getServerSession({ req });
+  const session = await getSession({ req });
   if (!session) {
     return res.status(401).json({ error: 'No autorizado' });
   }


### PR DESCRIPTION
The change from getServerSession to getSession aligns with the latest next-auth API recommendations, ensuring consistency and compatibility with the library's updates.